### PR TITLE
Fix: исправить ошибки сборки после мержа в main

### DIFF
--- a/edium/lib/domain/entities/course_detail.dart
+++ b/edium/lib/domain/entities/course_detail.dart
@@ -42,6 +42,7 @@ class CourseItem {
     required this.orderIndex,
     this.attemptId,
     this.score,
+    this.payload,
     this.title,
     this.quizType,
     this.state,

--- a/edium/lib/presentation/teacher/course_detail/bloc/course_detail_bloc.dart
+++ b/edium/lib/presentation/teacher/course_detail/bloc/course_detail_bloc.dart
@@ -11,16 +11,19 @@ class CourseDetailBloc extends Bloc<CourseDetailEvent, CourseDetailState> {
   final GetCourseDetailUsecase _getCourseDetail;
   final CreateModuleUsecase _createModule;
   final ProfileStorage _profileStorage;
+  final ICourseRepository _courseRepository;
   final String courseId;
 
   CourseDetailBloc({
     required GetCourseDetailUsecase getCourseDetail,
     required CreateModuleUsecase createModule,
     required ProfileStorage profileStorage,
+    required ICourseRepository courseRepository,
     required this.courseId,
   })  : _getCourseDetail = getCourseDetail,
         _createModule = createModule,
         _profileStorage = profileStorage,
+        _courseRepository = courseRepository,
         super(const CourseDetailInitial()) {
     on<LoadCourseDetailEvent>(_onLoad);
     on<SilentReloadCourseDetailEvent>(_onSilentReload);

--- a/edium/lib/presentation/teacher/course_detail/course_detail_screen.dart
+++ b/edium/lib/presentation/teacher/course_detail/course_detail_screen.dart
@@ -49,6 +49,7 @@ class CourseDetailScreen extends StatelessWidget {
         getCourseDetail: getIt(),
         createModule: getIt(),
         profileStorage: getIt(),
+        courseRepository: getIt(),
         courseId: courseId,
       )..add(LoadCourseDetailEvent(courseId)),
       child: const _CourseDetailView(),
@@ -261,7 +262,10 @@ class _CourseDetailBody extends StatelessWidget {
                         final draft = course.drafts[draftIndex - 1];
                         return Padding(
                           padding: const EdgeInsets.only(top: 8),
-                          child: _DraftTile(draft: draft),
+                          child: _DraftTile(
+                            draft: draft,
+                            onTap: () => _openCreateQuizFromDraft(context, draft),
+                          ),
                         );
                       },
                     ),


### PR DESCRIPTION
- course_detail.dart: вернуть this.payload в конструктор CourseItem (потерялось при мерж-конфликте)
- course_detail_bloc.dart: добавить ICourseRepository в конструктор блока (использовался, но не был инжектирован)
- course_detail_screen.dart: передать courseRepository: getIt() при создании блока; добавить onTap в _DraftTile